### PR TITLE
Fix build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
+	include("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
+		exclude(group: "net.fabricmc.fabric-api")
+	}
 }
 
 processResources {


### PR DESCRIPTION
When updating for 1.17 I mistakenly removed the `cloth-config` include. This causes `cloth-config` to not be bundled and without it MinimalMenu can't be configured. This PR readds the include.