### PR TITLE
Bump version to 1.19.2 and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 ![Game version](https://img.shields.io/badge/minecraft-1.19.2-blueviolet)
 ![Environment](https://img.shields.io/badge/environment-client-red)
 
-Minimal Menu is a small client side mod that allows the user independently toggle many buttons on the title screen and options screens. It also adds features like a button to reload saves, and view saves folder. Designed to work with mod menu and mod menu only.
+Minimal Menu is a small client side mod that allows the user independently toggle many buttons on the title screen and options screens. It also adds features like a button to reload saves, and view saves folder. Designed to work with Mod Menu and Mod Menu only.
 
 ![Imgur Image](https://i.imgur.com/PcamapY.jpg)
 
-*Requires [cloth config](https://www.curseforge.com/minecraft/mc-mods/cloth-config) and [mod menu](https://www.curseforge.com/minecraft/mc-mods/modmenu)
+*Requires Fabric API ( [CurseForge](https://www.curseforge.com/minecraft/mc-mods/fabric-api) / [Modrinth](https://modrinth.com/mod/fabric-api) ), Cloth Config API ( [CurseForge](https://www.curseforge.com/minecraft/mc-mods/cloth-config) / [Modrinth](https://modrinth.com/mod/cloth-config) ) and Mod Menu ( [CurseForge](https://www.curseforge.com/minecraft/mc-mods/modmenu) / [Modrinth](https://modrinth.com/mod/modmenu) )
 
 ## Features
 * Pause the rendering of the background panorama
@@ -29,13 +29,13 @@ Minimal Menu is a small client side mod that allows the user independently toggl
 * Remove the Realms notification button from the options screen
 * Remove the feedback button from the pause screen
 * Remove the bug report button from the pause screen
-* Remove the open to lan button
-* Remove the player reporting button
+* Remove the open to lan button from the pause screen
+* Remove the player reporting button from the pause screen
 
 ## Installation
 
 1. Download and install Fabric from [here](https://fabricmc.net/use)
-2. Download Fabric API mod from [here](https://www.curseforge.com/minecraft/mc-mods/fabric-api) and place in your mods folder.
-3. Download Modmenu from [CurseForge](https://www.curseforge.com/minecraft/mc-mods/modmenu) (Required to be able to configure mod, all settings are off by default.)
-4. Download Cloth config from [CurseForge](https://www.curseforge.com/minecraft/mc-mods/cloth-config)
-5. Download Minimal Menu from [the github page](https://github.com/TomB-134/MinimalMenu/releases) or from [CurseForge](https://www.curseforge.com/minecraft/mc-mods/minimal-menu) and place in your mods folder.
+2. Download Fabric API mod from [CurseForge](https://www.curseforge.com/minecraft/mc-mods/fabric-api) or [Modrinth](https://modrinth.com/mod/fabric-api) and place in your mods folder.
+3. Download Mod Menu mod from [CurseForge](https://www.curseforge.com/minecraft/mc-mods/modmenu) or [Modrinth](https://modrinth.com/mod/modmenu) (Required to be able to configure mod, all settings are off by default.)
+4. Download Cloth Config API mod from [CurseForge](https://www.curseforge.com/minecraft/mc-mods/cloth-config) or [Modrinth](https://modrinth.com/mod/cloth-config) (Remember to choose the Fabric version of the mod.)
+5. Download Minimal Menu mod from [the GitHub page](https://github.com/TomB-134/MinimalMenu/releases), from [CurseForge](https://www.curseforge.com/minecraft/mc-mods/minimal-menu) or from [Modrinth](https://modrinth.com/mod/minimalmenu) and place in your mods folder.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Minimal Menu
 
 ![GitHub license](https://img.shields.io/badge/license-MIT-blue)
-![Game version](https://img.shields.io/badge/minecraft-1.19-blueviolet)
+![Game version](https://img.shields.io/badge/minecraft-1.19.2-blueviolet)
 ![Environment](https://img.shields.io/badge/environment-client-red)
 
 Minimal Menu is a small client side mod that allows the user independently toggle many buttons on the title screen and options screens. It also adds features like a button to reload saves, and view saves folder. Designed to work with mod menu and mod menu only.
@@ -29,8 +29,8 @@ Minimal Menu is a small client side mod that allows the user independently toggl
 * Remove the Realms notification button from the options screen
 * Remove the feedback button from the pause screen
 * Remove the bug report button from the pause screen
-* Remove the open to lan button in singleplayer
-* Remove the open to lan button in multiplayer
+* Remove the open to lan button
+* Remove the player reporting button
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![GitHub license](https://img.shields.io/badge/license-MIT-blue)
 ![Game version](https://img.shields.io/badge/minecraft-1.19.2-blueviolet)
 ![Environment](https://img.shields.io/badge/environment-client-red)
-![Mod loader](https://img.shields.io/badge/mod_loader-fabric-green)
+![Mod loader](https://img.shields.io/badge/mod_loader-fabric-darkgreen)
 
 Minimal Menu is a small client side mod that allows the user independently toggle many buttons on the title screen and options screens. It also adds features like a button to reload saves, and view saves folder. Designed to work with Mod Menu and Mod Menu only.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub license](https://img.shields.io/badge/license-MIT-blue)
 ![Game version](https://img.shields.io/badge/minecraft-1.19.2-blueviolet)
 ![Environment](https://img.shields.io/badge/environment-client-red)
+![Mod loader](https://img.shields.io/badge/mod_loader-fabric-green)
 
 Minimal Menu is a small client side mod that allows the user independently toggle many buttons on the title screen and options screens. It also adds features like a button to reload saves, and view saves folder. Designed to work with Mod Menu and Mod Menu only.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 org.gradle.jvmargs   = -Xmx1G
 
 #Fabric properties
-minecraft_version    = 1.19
+minecraft_version    = 1.19.2
 yarn_mappings        = 1.19+build.1
 loader_version       = 0.14.7
 
 #Mod properties
-mod_version          = 1.19-0.1.5
+mod_version          = 1.19.2-0.1.6
 maven_group          = minimalmenu
 archives_base_name   = minimalmenu
 

--- a/src/main/resources/assets/minimalmenu/lang/en_us.json
+++ b/src/main/resources/assets/minimalmenu/lang/en_us.json
@@ -28,7 +28,7 @@
   "minimalmenu.config.option.pause.feedback": "Remove Feedback",
   "minimalmenu.config.option.pause.bugs": "Remove Report Bugs",
   "minimalmenu.config.option.pause.reporting": "Remove Player Reporting",
-  "minimalmenu.config.option.pause.lanSingle": "Remove Open To Lan in Singleplayer",
+  "minimalmenu.config.option.pause.lanSingle": "Remove Open To Lan",
   "minimalmenu.config.option.pause.xOffset": "X Offset",
   "minimalmenu.config.option.pause.yOffset": "Y Offset",
   "minimalmenu.config.option.sp.addSavesFolder": "Add Saves Folder Button",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -10,7 +10,8 @@
   "contributors": [
     "jackassmc",
     "umollu",
-    "huiki"
+    "huiki",
+    "TGODiamond"
   ],
   "contact": {
     "homepage": "https://github.com/TomB-134/MinimalMenu",


### PR DESCRIPTION
Remember to release this version of the MinimalMenu mod to CurseForge, Modrinth and optionally GitHub after merging

From 1.19-0.1.5 to 1.19.2-0.1.6

This PR also makes an update to the "README.md" file to add links to both CurseForge and Modrinth plus more